### PR TITLE
added an option to give name hint for serial connect 

### DIFF
--- a/jupyter_micropython_kernel/deviceconnector.py
+++ b/jupyter_micropython_kernel/deviceconnector.py
@@ -144,6 +144,8 @@ class DeviceConnector:
             self.sres("Found multiple serial ports: {} \n".format(", ".join(portsfound)))
             if len(portsfound)>0:
                 portname = portsfound[0]
+        else:
+            self.sresSYS("No Name hint provided, will connect on %d" % portname)
 
         if type(portname) is int:
             portindex = portname

--- a/jupyter_micropython_kernel/deviceconnector.py
+++ b/jupyter_micropython_kernel/deviceconnector.py
@@ -137,8 +137,14 @@ class DeviceConnector:
             self.workingwebsocket.close()
             self.workingwebsocket = None
 
-    def serialconnect(self, portname, baudrate, verbose):
+    def serialconnect(self, portname, baudrate, verbose=False, name_hint=None):
         assert not  self.workingserial
+        if name_hint is not None:
+            portsfound = self.find_connected_boards(name_hint)
+            self.sres("Found multiple serial ports: {} \n".format(", ".join(portsfound)))
+            if len(portsfound)>0:
+                portname = portsfound[0]
+
         if type(portname) is int:
             portindex = portname
             possibleports = guessserialport()
@@ -513,5 +519,16 @@ class DeviceConnector:
 
     def serialexists(self):
         return self.workingserial or self.workingsocket or self.workingwebsocket
-        
-        
+
+    @staticmethod
+    def find_connected_boards(name_hint=""):
+        """
+        Returns name of com ports where hint is part of port description
+        :return: list of string representing com ports
+        """
+        ports = list(serial.tools.list_ports.comports())
+        connected = []
+        for p in ports:
+            if name_hint in p[1]:
+                connected.append(p[0])
+        return connected

--- a/jupyter_micropython_kernel/deviceconnector.py
+++ b/jupyter_micropython_kernel/deviceconnector.py
@@ -141,11 +141,11 @@ class DeviceConnector:
         assert not  self.workingserial
         if name_hint is not None:
             portsfound = self.find_connected_boards(name_hint)
-            self.sres("Found multiple serial ports: {} \n".format(", ".join(portsfound)))
+            self.sres("found ports using name hint ({}): {} \n".format(name_hint, ", ".join(portsfound)))
             if len(portsfound)>0:
                 portname = portsfound[0]
-        else:
-            self.sresSYS("No Name hint provided, will connect on %d" % portname)
+        
+            self.sresSYS("Will connect on %s\n" % portname)
 
         if type(portname) is int:
             portindex = portname

--- a/jupyter_micropython_kernel/kernel.py
+++ b/jupyter_micropython_kernel/kernel.py
@@ -19,6 +19,7 @@ import argparse, shlex
 ap_serialconnect = argparse.ArgumentParser(prog="%serialconnect", add_help=False)
 ap_serialconnect.add_argument('--raw', help='Just open connection', action='store_true')
 ap_serialconnect.add_argument('--port', type=str, default=0)
+ap_serialconnect.add_argument('--name_hint', type=str, default=None)
 ap_serialconnect.add_argument('--baud', type=int, default=115200)
 ap_serialconnect.add_argument('--verbose', action='store_true')
 
@@ -145,7 +146,7 @@ class MicroPythonKernel(Kernel):
             apargs = parseap(ap_serialconnect, percentstringargs[1:])
             
             self.dc.disconnect(apargs.verbose)
-            self.dc.serialconnect(apargs.port, apargs.baud, apargs.verbose)
+            self.dc.serialconnect(apargs.port, apargs.baud, verbose=apargs.verbose, name_hint=apargs.name_hint)
             if self.dc.workingserial:
                 if not apargs.raw:
                     if self.dc.enterpastemode(verbose=apargs.verbose):


### PR DESCRIPTION
Now user can pass additional argument in %serialconnect --name_hint="hint"
We will try to find serial port matching name hint and will connect to that.

For example for OpenMV boards.

--name_hint="Open"

